### PR TITLE
Fix check for valid package URL.

### DIFF
--- a/src/Clue/PharComposer/Phar/Packager.php
+++ b/src/Clue/PharComposer/Phar/Packager.php
@@ -327,7 +327,7 @@ class Packager
 
     public function isPackageUrl($path)
     {
-        return (strpos($path, '://') !== false && @parse_url($path) !== false) || preg_match('/^[^-\s][^:\s]*:\S+/', $path);
+        return (strpos($path, '://') !== false && @parse_url($path) !== false) || preg_match('/^[^-\/\s][^:\/\s]*:\S+/', $path);
     }
 
     private function getDirTemporary()

--- a/tests/Phar/PackagerTest.php
+++ b/tests/Phar/PackagerTest.php
@@ -147,6 +147,12 @@ class PackagerTest extends TestCase
     {
         return array(
             array('clue/phar-composer'),
+            array('clue/phar-composer:^1.0'),
+            array('clue/phar-composer:~1.0'),
+            array('clue/packagewithoutdashes'),
+            array('clue/packagewithoutdashes:1.2.34'),
+            array('clue/packagewithoutdashes:^1.2.34'),
+            array('clue/packagewithoutdashes:~1.2.34'),
             array('phar-composer.git'),
             array('github.com/clue/phar-composer.git'),
             array('git @github.com:clue/phar-composer.git'),


### PR DESCRIPTION
This regex pattern used to accept some package names, those include:

- Package names without dashes
- Packages with version ranges

Respective examples have been added to the existing test.

Fixes #101.